### PR TITLE
fix: filter on date range before file

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -1286,17 +1286,17 @@ func (r *Repository) Log(o *LogOptions) (object.CommitIter, error) {
 		return nil, err
 	}
 
+	if o.Since != nil || o.Until != nil || !o.To.IsZero() {
+		limitOptions := object.LogLimitOptions{Since: o.Since, Until: o.Until, TailHash: o.To}
+		it = r.logWithLimit(it, limitOptions)
+	}
+	
 	if o.FileName != nil {
 		// for `git log --all` also check parent (if the next commit comes from the real parent)
 		it = r.logWithFile(*o.FileName, it, o.All)
 	}
 	if o.PathFilter != nil {
 		it = r.logWithPathFilter(o.PathFilter, it, o.All)
-	}
-
-	if o.Since != nil || o.Until != nil || !o.To.IsZero() {
-		limitOptions := object.LogLimitOptions{Since: o.Since, Until: o.Until, TailHash: o.To}
-		it = r.logWithLimit(it, limitOptions)
 	}
 
 	return it, nil


### PR DESCRIPTION
It is much more efficient to evaluate a date range than checking all files of a commit.

Fixes #1659